### PR TITLE
gemi: Fix loading of local .env file

### DIFF
--- a/main.py
+++ b/main.py
@@ -3,7 +3,8 @@ import sys
 from aiohttp.web import Application, run_app
 import sentry_sdk
 from sentry_sdk.integrations.logging import LoggingIntegration
-from os import getenv
+from os import getenv, path
+from dotenv import load_dotenv
 
 from containers import BotContainer, Configs
 from api.routes import routes
@@ -67,6 +68,8 @@ def init_bot(app: Application):
     BotContainer.voice_engine()
 
 async def web_app():
+    if path.exists(".env"):
+        load_dotenv()
     log_integration()
 
     app = Application()

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ duckduckgo-search~=4.1.1
 sentry_sdk~=1.39.1
 re_edge_gpt~=0.0.20
 md2tgmd @ git+https://github.com/yym68686/md2tgmd.git
+python-dotenv~=1.0.1


### PR DESCRIPTION
* vs code already loads the .env as environment variables in terminal context, thus it was unnoticed